### PR TITLE
fix(journey): ground evidence against the repo and schema before assembly

### DIFF
--- a/src/skene/analyzers/journey/ground.py
+++ b/src/skene/analyzers/journey/ground.py
@@ -1,0 +1,125 @@
+"""Ground-check synthesized evidence against the run's actual sources.
+
+The subagents explore through sandboxed tools (``FsTools``,
+``SchemaToolset``), but their final answer is generated JSON — a claim,
+not a transcript of what they opened. ``Evidence.check_source_fields``
+only enforces that ``source='code'`` carries a non-empty ``path`` and
+``source='db'`` a non-empty ``table``; nothing resolves either against
+the repo or the introspected schema. A plausible-looking fabricated
+citation is therefore schema-valid and ships in ``journey.yaml`` at
+whatever confidence the model self-reported.
+
+This step closes that gap deterministically, with no extra LLM call:
+
+- ``source='code'`` chips must name a path that exists inside
+  ``repo_root`` (same relative/no-``..``/no-escape rules as
+  ``FsTools._resolve``).
+- ``source='db'`` chips must name a table the schema source actually
+  contains (matched case-insensitively, ignoring schema qualification —
+  agents cite ``public.users`` while introspection records ``users``).
+- ``source='config'`` chips are checked like code chips when they carry
+  a path, and kept as-is otherwise.
+
+Chips that resolve to nothing are dropped, candidates left with no
+evidence at all are dropped, and confidence is scaled by the fraction of
+evidence that survived. Every check is opt-in: with ``repo_root=None``
+code chips are not checked, and with ``known_tables=None`` db chips are
+not checked, so callers without those sources see unchanged behaviour.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from skene.analyzers.journey.candidate import CandidateMilestone
+from skene.analyzers.journey.models import Evidence, EvidenceSource
+
+
+@dataclass
+class GroundingReport:
+    """What grounding removed, for the status line and for tests."""
+
+    dropped_evidence: list[tuple[str, Evidence]] = field(default_factory=list)
+    dropped_milestones: list[str] = field(default_factory=list)
+
+    @property
+    def evidence_count(self) -> int:
+        return len(self.dropped_evidence)
+
+    @property
+    def milestone_count(self) -> int:
+        return len(self.dropped_milestones)
+
+
+def ground_candidates(
+    candidates: list[CandidateMilestone],
+    repo_root: Path | None = None,
+    known_tables: set[str] | None = None,
+) -> tuple[list[CandidateMilestone], GroundingReport]:
+    """Drop evidence that does not resolve against the run's sources.
+
+    Returns the surviving candidates plus a report of what was removed.
+    Candidates whose evidence all failed grounding are removed entirely
+    (an unproven milestone is not patched around), and the confidence of
+    partially grounded candidates is scaled by the surviving fraction.
+    """
+    report = GroundingReport()
+    if repo_root is None and known_tables is None:
+        return candidates, report
+
+    root = repo_root.resolve() if repo_root is not None else None
+    table_names = {_normalize_table(t) for t in known_tables} if known_tables is not None else None
+
+    kept_candidates: list[CandidateMilestone] = []
+    for cm in candidates:
+        kept: list[Evidence] = []
+        for ev in cm.evidence:
+            if _is_grounded(ev, root, table_names):
+                kept.append(ev)
+            else:
+                report.dropped_evidence.append((cm.proposed_id, ev))
+        if not kept:
+            report.dropped_milestones.append(cm.proposed_id)
+            continue
+        if len(kept) < len(cm.evidence):
+            scale = len(kept) / len(cm.evidence)
+            cm = cm.model_copy(
+                update={
+                    "evidence": kept,
+                    "confidence": round(cm.confidence * scale, 4),
+                }
+            )
+        kept_candidates.append(cm)
+    return kept_candidates, report
+
+
+def _is_grounded(ev: Evidence, root: Path | None, table_names: set[str] | None) -> bool:
+    if ev.source == EvidenceSource.db:
+        if table_names is None or ev.table is None:
+            return True
+        return _normalize_table(ev.table) in table_names
+    # code always carries a path (model-enforced); config only sometimes.
+    if ev.path is None or root is None:
+        return True
+    return _path_exists_in_root(root, ev.path)
+
+
+def _normalize_table(name: str) -> str:
+    """Case-fold and strip schema qualification (``public.users`` → ``users``)."""
+    return name.lower().rsplit(".", 1)[-1]
+
+
+def _path_exists_in_root(root: Path, rel: str) -> bool:
+    """Same containment rules as ``FsTools._resolve``, plus existence."""
+    if not rel or rel in (".", "./"):
+        return True
+    p = Path(rel)
+    if p.is_absolute() or ".." in p.parts:
+        return False
+    try:
+        target = (root / p).resolve()
+        target.relative_to(root)
+    except (ValueError, OSError):
+        return False
+    return target.exists()

--- a/src/skene/core/journey.py
+++ b/src/skene/core/journey.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 from skene.analyzers.journey.assemble import assemble_journey
 from skene.analyzers.journey.feature_map import write_features
+from skene.analyzers.journey.ground import ground_candidates
 from skene.analyzers.journey.merge import merge_features_llm
 from skene.analyzers.journey.models import Journey
 from skene.analyzers.journey.serialize import write as write_journey
@@ -322,6 +323,17 @@ async def _synthesize_journey(ctx: JourneyRunContext) -> str:
         classify_concurrency=ctx.config.classify_concurrency,
         sources=_sources_display(ctx.config),
     )
+    known_tables: set[str] | None = None
+    if ctx.config.schema_dir is not None or ctx.config.db_url is not None:
+        index = await ctx.schema_index()
+        known_tables = {t.name for tables in index.files.values() for t in tables}
+    candidates, grounding = ground_candidates(candidates, repo_root=ctx.config.repo_root, known_tables=known_tables)
+    if grounding.evidence_count or grounding.milestone_count:
+        status(
+            f"synthesize: grounding dropped {grounding.evidence_count} unverifiable "
+            f"evidence chip(s) and {grounding.milestone_count} milestone(s) left without proof"
+        )
+
     journey = assemble_journey(candidates, product_name=ctx.config.product_name, stages=stages)
 
     write_journey(journey, output)

--- a/tests/test_journey/test_ground.py
+++ b/tests/test_journey/test_ground.py
@@ -1,0 +1,102 @@
+"""Tests for ground_candidates (evidence grounding before assembly)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from skene.analyzers.journey.candidate import CandidateMilestone
+from skene.analyzers.journey.ground import ground_candidates
+from skene.analyzers.journey.models import Evidence
+
+
+def _candidate(
+    pid: str,
+    evidence: list[Evidence],
+    *,
+    confidence: float = 0.9,
+    stage_id: str = "onboarding",
+) -> CandidateMilestone:
+    return CandidateMilestone(
+        proposed_id=pid,
+        name=pid,
+        description=pid,
+        evidence=evidence,
+        confidence=confidence,
+        stage_id=stage_id,
+    )
+
+
+def _repo(tmp_path: Path) -> Path:
+    (tmp_path / "src" / "auth").mkdir(parents=True)
+    (tmp_path / "src" / "auth" / "signup.py").write_text("def signup(): ...\n")
+    return tmp_path
+
+
+def test_hallucinated_code_path_is_dropped_and_confidence_scaled(tmp_path):
+    root = _repo(tmp_path)
+    cm = _candidate(
+        "signup",
+        [
+            Evidence(source="code", path="src/auth/signup.py", reason="real"),
+            Evidence(source="code", path="src/auth/does_not_exist.py", reason="ghost"),
+        ],
+        confidence=0.95,
+    )
+    kept, report = ground_candidates([cm], repo_root=root)
+    assert len(kept) == 1
+    assert [ev.path for ev in kept[0].evidence] == ["src/auth/signup.py"]
+    assert kept[0].confidence == 0.475  # 0.95 * 1/2
+    assert report.evidence_count == 1
+    assert report.milestone_count == 0
+
+
+def test_milestone_with_only_ghost_evidence_is_dropped(tmp_path):
+    root = _repo(tmp_path)
+    cm = _candidate(
+        "phantom",
+        [Evidence(source="code", path="src/never/was.py", reason="ghost")],
+    )
+    kept, report = ground_candidates([cm], repo_root=root)
+    assert kept == []
+    assert report.milestone_count == 1
+    assert report.dropped_milestones == ["phantom"]
+
+
+def test_db_table_checked_against_introspected_schema(tmp_path):
+    real = _candidate("orders", [Evidence(source="db", table="Orders", reason="row")])
+    qualified = _candidate("users", [Evidence(source="db", table="public.users", reason="row")])
+    ghost = _candidate("ghosts", [Evidence(source="db", table="unicorns", reason="row")])
+    kept, report = ground_candidates([real, qualified, ghost], known_tables={"orders", "users"})
+    assert [c.proposed_id for c in kept] == ["orders", "users"]
+    assert kept[0].confidence == 0.9  # untouched: all evidence survived
+    assert report.milestone_count == 1
+
+
+def test_escaping_or_absolute_paths_are_ungrounded(tmp_path):
+    root = _repo(tmp_path)
+    cm = _candidate(
+        "escape",
+        [
+            Evidence(source="code", path="../outside.py", reason="escape"),
+            Evidence(source="code", path="/etc/passwd", reason="absolute"),
+            Evidence(source="code", path="src/auth/signup.py", reason="real"),
+        ],
+    )
+    kept, report = ground_candidates([cm], repo_root=root)
+    assert len(kept) == 1
+    assert [ev.path for ev in kept[0].evidence] == ["src/auth/signup.py"]
+    assert report.evidence_count == 2
+
+
+def test_no_sources_means_no_change(tmp_path):
+    cm = _candidate(
+        "legacy",
+        [
+            Evidence(source="code", path="src/never/checked.py", reason="unchecked"),
+            Evidence(source="db", table="unchecked", reason="unchecked"),
+        ],
+    )
+    kept, report = ground_candidates([cm])
+    assert kept == [cm]
+    assert report.evidence_count == 0
+    assert report.milestone_count == 0


### PR DESCRIPTION
Following up on the finding Teemu verified over email. Targeting `v1.0` directly rather than `main`, per the heads-up about the journey pipeline restructure.

## The hole

The subagents explore through sandboxed tools, but their final answer is generated JSON: a claim, not a transcript of what they actually opened. `Evidence.check_source_fields` only enforces that `source='code'` carries a non-empty `path` (and `db` a `table`), and the round-trip in the assemble step validates shape, not grounding. Nothing in `src/` resolves `evidence.path` against the filesystem.

So a fabricated citation like `src/auth/signup.py`, for a file that never existed, is schema-valid and ships in `journey.yaml` at whatever confidence the model self-reported. The prompt does ask the agent to cite real files, but that is a request, not a check.

## The change

A deterministic grounding step between synthesis and assembly. No extra LLM call.

- `code` chips must resolve inside `repo_root` under the same containment rules as `FsTools._resolve`, and must exist.
- `db` chips must name a table the run's schema source actually contains, case-insensitive and schema-qualification-insensitive, so an agent citing `public.users` matches an introspected `users`.
- `config` chips are checked like code when they carry a path, and kept otherwise.
- Ungrounded chips are dropped, milestones left with no evidence are dropped, and confidence is scaled by the fraction of evidence that survived.

Everything is opt-in. Without a repo root or a schema source the respective checks are skipped, so existing callers see unchanged behaviour. `known_tables` is sourced from the run's cached `SchemaIndex` and only when a schema source is configured, so this triggers no spurious introspection.

## Test plan

```
uv run ruff check src/ tests/
uv run ruff format --check
uv run pytest tests/
```

336 passed, 6 pre-existing skips, against a baseline of 331 passed. The golden parity test passes untouched, which is the backward-compatibility proof.

New tests in `tests/test_journey/test_ground.py` cover five cases: hallucinated path dropped with confidence scaled, all-ghost milestone dropped entirely, db table matched against an introspected schema including the `public.` qualification, `../` escapes and absolute paths treated as ungrounded, and no-sources backward compatibility.

Happy to rebase or re-scope this however suits the v1.0 work best.
