### PR TITLE
fix(cli, schema): fix activation plan crash and pg foreign key grouping

### DIFF
--- a/src/skene/analyzers/schema_parsers/postgres_live.py
+++ b/src/skene/analyzers/schema_parsers/postgres_live.py
@@ -154,6 +154,7 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
         fk_query = """\
             SELECT nsp.nspname AS schema_name,
                    cl.relname AS table_name,
+                   fk.conname AS constraint_name,
                    array_agg(att.attname ORDER BY sub) AS columns,
                    ref_nsp.nspname AS references_schema,
                    ref_cl.relname AS references_table,
@@ -171,7 +172,7 @@ def introspect_db(db_url: str, *, connect_timeout: int = 10) -> SchemaIndex:
             WHERE fk.contype = 'f'
               AND cl.relname = ANY(%s)
               AND nsp.nspname = ANY(%s)
-            GROUP BY nsp.nspname, cl.relname, ref_nsp.nspname, ref_cl.relname
+            GROUP BY nsp.nspname, cl.relname, fk.conname, ref_nsp.nspname, ref_cl.relname
         """
         with conn.cursor() as cur:
             cur.execute(fk_query, (table_names, user_schemas))

--- a/src/skene/cli/analysis_helpers.py
+++ b/src/skene/cli/analysis_helpers.py
@@ -550,8 +550,8 @@ async def run_generate_plan(
                     extract_next_action,
                 )
 
-                executive_summary = extract_executive_summary(memo_content)
-                todo_summary = extract_next_action(memo_content)
+                executive_summary = extract_executive_summary(output_path)
+                todo_summary = extract_next_action(output_path)
 
             # Print summary (dynamic sections + Technical Execution; exec summary disabled)
             middle_count = len(growth_plan.sections) if growth_plan else 0

--- a/src/skene/cli/prompt_builder.py
+++ b/src/skene/cli/prompt_builder.py
@@ -12,25 +12,32 @@ from skene.output import status, warning
 from skene.progress import run_with_progress
 
 
-def _load_growth_plan_json(plan_path: Path) -> dict | None:
+def _load_growth_plan_json(plan_path: Path | str) -> dict | None:
     """Load growth-plan.json from the same directory as the plan markdown file.
 
     Args:
-        plan_path: Path to the growth-plan.md file
+        plan_path: Path to the growth-plan.md file (or path string)
 
     Returns:
         Parsed JSON dict or None if not found
     """
-    json_path = plan_path.with_suffix(".json")
-    if not json_path.exists():
+    if isinstance(plan_path, str):
+        if "\n" in plan_path or plan_path.startswith("#"):
+            return None
+        plan_path = Path(plan_path)
+    elif not isinstance(plan_path, Path):
         return None
+
     try:
-        return json.loads(json_path.read_text())
-    except (json.JSONDecodeError, OSError):
+        json_path = plan_path.with_suffix(".json")
+        if not json_path.exists():
+            return None
+        return json.loads(json_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, ValueError, TypeError):
         return None
 
 
-def extract_executive_summary(plan_path: Path) -> str | None:
+def extract_executive_summary(plan_path: Path | str) -> str | None:
     """Extract the Executive Summary from the growth plan JSON.
 
     Args:
@@ -45,7 +52,7 @@ def extract_executive_summary(plan_path: Path) -> str | None:
     return data.get("executive_summary") or None
 
 
-def extract_next_action(plan_path: Path) -> str | None:
+def extract_next_action(plan_path: Path | str) -> str | None:
     """Extract 'The Next Action' section from the growth plan JSON.
 
     Args:
@@ -63,7 +70,7 @@ def extract_next_action(plan_path: Path) -> str | None:
     return None
 
 
-def extract_technical_execution(plan_path: Path) -> dict[str, str] | None:
+def extract_technical_execution(plan_path: Path | str) -> dict[str, str] | None:
     """Extract the Technical Execution section from the growth plan JSON.
 
     Args:

--- a/tests/test_cli/test_plan_activation.py
+++ b/tests/test_cli/test_plan_activation.py
@@ -1,0 +1,64 @@
+"""Tests for activation plan generation flow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from skene.cli.analysis_helpers import run_generate_plan
+from skene.cli.prompt_builder import (
+    extract_executive_summary,
+    extract_next_action,
+    extract_technical_execution,
+)
+
+
+def test_extract_helpers_defensive_against_string_and_invalid_inputs(tmp_path: Path):
+    """extract_* functions must not raise AttributeError when passed markdown text or non-existent paths."""
+    assert extract_executive_summary("# Markdown content\n\nSome text") is None
+    assert extract_next_action("Some string without path") is None
+    assert extract_technical_execution("# Some header") is None
+
+    # When pointing to a non-existent path
+    non_existent = tmp_path / "non_existent.md"
+    assert extract_executive_summary(non_existent) is None
+    assert extract_next_action(non_existent) is None
+    assert extract_technical_execution(non_existent) is None
+
+
+@pytest.mark.asyncio
+async def test_run_generate_plan_activation_mode(tmp_path: Path):
+    """run_generate_plan with activation=True should succeed without crashing on string with_suffix."""
+    manifest_file = tmp_path / "growth-manifest.json"
+    manifest_file.write_text('{"project_name": "TestApp", "current_growth_features": []}')
+
+    template_file = tmp_path / "growth-template.json"
+    template_file.write_text('{"lifecycles": []}')
+
+    output_path = tmp_path / "growth-plan.md"
+
+    mock_llm = MagicMock()
+    mock_llm.generate_content = AsyncMock(return_value="## Activation Memo\n\n1. Focus on onboarding flow.")
+
+    with (
+        patch("skene.llm.create_llm_client", return_value=mock_llm),
+        patch("skene.cli.analysis_helpers.generate_todo_list", AsyncMock(return_value="- [ ] Implement welcome email")),
+    ):
+            memo_content, summaries = await run_generate_plan(
+                manifest_path=manifest_file,
+                template_path=template_file,
+                output_path=output_path,
+                api_key="mock-key",
+                provider="openai",
+                model="gpt-4o",
+                activation=True,
+                context_dir=tmp_path,
+            )
+
+    assert memo_content is not None
+    assert "Activation Memo" in memo_content
+    assert "## Todo" in memo_content
+    assert output_path.exists()
+    assert "Activation Memo" in output_path.read_text()

--- a/tests/test_schema_parsers/test_postgres_live.py
+++ b/tests/test_schema_parsers/test_postgres_live.py
@@ -222,6 +222,85 @@ class TestIntrospectDb:
                 assert fk.references_table == "users"
                 assert fk.references_columns == ["id"]
 
+    def test_multiple_foreign_keys_to_same_referenced_table(self):
+        """Separate foreign keys to the same table are not incorrectly grouped into a single composite FK."""
+        mock_conn = _build_mock_conn(
+            schemas=["public"],
+            tables=[("public", "orders"), ("public", "users")],
+            pk_rows=[
+                {"schema_name": "public", "table_name": "orders", "pk_columns": ["id"]},
+                {"schema_name": "public", "table_name": "users", "pk_columns": ["id"]},
+            ],
+            col_rows=[
+                {
+                    "schema_name": "public",
+                    "table_name": "orders",
+                    "column_name": "id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+                {
+                    "schema_name": "public",
+                    "table_name": "orders",
+                    "column_name": "buyer_id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+                {
+                    "schema_name": "public",
+                    "table_name": "orders",
+                    "column_name": "seller_id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+                {
+                    "schema_name": "public",
+                    "table_name": "users",
+                    "column_name": "id",
+                    "data_type": "uuid",
+                    "is_nullable": "NO",
+                    "column_default": None,
+                },
+            ],
+            fk_rows=[
+                {
+                    "schema_name": "public",
+                    "table_name": "orders",
+                    "constraint_name": "orders_buyer_id_fkey",
+                    "columns": ["buyer_id"],
+                    "references_schema": "public",
+                    "references_table": "users",
+                    "references_columns": ["id"],
+                },
+                {
+                    "schema_name": "public",
+                    "table_name": "orders",
+                    "constraint_name": "orders_seller_id_fkey",
+                    "columns": ["seller_id"],
+                    "references_schema": "public",
+                    "references_table": "users",
+                    "references_columns": ["id"],
+                },
+            ],
+            idx_rows=[],
+        )
+        with patch("psycopg.connect", return_value=mock_conn):
+            index = introspect_db("postgresql://user:pass@localhost/db")
+
+        orders_tables = index.files["public.orders.sql"]
+        orders_t = next(t for t in orders_tables if t.name == "orders")
+        assert len(orders_t.foreign_keys) == 2
+        fks_by_col = {tuple(fk.columns): fk for fk in orders_t.foreign_keys}
+        assert ("buyer_id",) in fks_by_col
+        assert ("seller_id",) in fks_by_col
+        assert fks_by_col[("buyer_id",)].references_table == "users"
+        assert fks_by_col[("buyer_id",)].references_columns == ["id"]
+        assert fks_by_col[("seller_id",)].references_table == "users"
+        assert fks_by_col[("seller_id",)].references_columns == ["id"]
+
     def test_views_included(self):
         """Views are included in the schema index."""
         mock_conn = _build_mock_conn(


### PR DESCRIPTION
## Summary

Fixes two critical bugs:
1. **Fatal `AttributeError` crash on `skene plan --activation`**: `run_generate_plan` passed `memo_content` (a string containing markdown text) instead of `output_path` (a `Path` object) into `extract_executive_summary` and `extract_next_action`, causing `plan_path.with_suffix(".json")` to fail with `AttributeError: 'str' object has no attribute 'with_suffix'`.
2. **PostgreSQL live introspection foreign key grouping corruption**: `fk_query` in `postgres_live.py` grouped only by `(schema_name, table_name, references_schema, references_table)` without constraint identification (`fk.conname`), causing tables with multiple foreign keys referencing the same target table (e.g., `buyer_id` and `seller_id` both referencing `users(id)`) to be incorrectly collapsed into a single invalid composite foreign key.

---

## Detailed Changes

### 1. CLI Growth Planner (`src/skene/cli/analysis_helpers.py` & `src/skene/cli/prompt_builder.py`)
- In `analysis_helpers.py:run_generate_plan`: Pass `output_path` instead of `memo_content` to `extract_executive_summary()` and `extract_next_action()`.
- In `prompt_builder.py:_load_growth_plan_json`: Added defensive type and content guards to gracefully return `None` when given strings or invalid inputs rather than raising uncaught exceptions.
- Added full unit test coverage in `tests/test_cli/test_plan_activation.py` testing `run_generate_plan(..., activation=True)` end-to-end.

### 2. PostgreSQL Live Introspection (`src/skene/analyzers/schema_parsers/postgres_live.py`)
- In `postgres_live.py:introspect_db`: Added `fk.conname AS constraint_name` to `SELECT` and `GROUP BY` in `fk_query`, ensuring distinct foreign key constraints between the same two tables produce distinct `ForeignKey` records.
- Added `test_multiple_foreign_keys_to_same_referenced_table` in `tests/test_schema_parsers/test_postgres_live.py`.

---

## Verification Plan

- `python -m uv run pytest -m "not db"` (425 passed, 2 skipped, 5 deselected)
- `python -m uv run ruff check src/ tests/` (all checks passed)
